### PR TITLE
feat(go): switch to neotest-golang

### DIFF
--- a/lua/plugins/neotest.lua
+++ b/lua/plugins/neotest.lua
@@ -4,7 +4,7 @@ return {
     "nvim-lua/plenary.nvim",
     "nvim-treesitter/nvim-treesitter",
     "antoinemadec/FixCursorHold.nvim",
-    "nvim-neotest/neotest-go",
+    "nvim-neotest/neotest-golang",
   },
   keys = {
     {
@@ -74,7 +74,7 @@ return {
     require("neotest").setup({
       -- your neotest config here
       adapters = {
-        require("neotest-go"),
+        require("neotest-golang"),
       },
       icons = {
         child_indent = "│",


### PR DESCRIPTION
hey @adibhanna I've come across your repo a few times and just figured I'd contribute back 😄 

## What is this PR for?

This PR switches [nvim-neotest/neotest-go](https://github.com/nvim-neotest/neotest-go) for [fredrikaverpil/neotest-golang](https://github.com/fredrikaverpil/neotest-golang).

## Does this PR fix an existing issue?

Neotest-go comes with some problems which are mitigated in neotest-golang. A full description/background is available in the project README, but here are some highlights:

### Neotest-go issues mitigated in neotest-golang

- Support for Testify framework: [neotest-go#6](https://github.com/nvim-neotest/neotest-go/issues/6)
- Test Output in JSON, making it difficult to read:  [neotest-go#52](https://github.com/nvim-neotest/neotest-go/issues/52)
- "Run nearest" runs all tests:  [neotest-go#83](https://github.com/nvim-neotest/neotest-go/issues/83)
- Running test suite doesn't work:  [neotest-go#89](https://github.com/nvim-neotest/neotest-go/issues/89)
- Diagnostics for table tests on the line of failure:  [neotest-go#75](https://github.com/nvim-neotest/neotest-go/issues/75)
- Support for Nested Subtests:  [neotest-go#74](https://github.com/nvim-neotest/neotest-go/issues/74)
- DAP support:  [neotest-go#12](https://github.com/nvim-neotest/neotest-go/issues/12)

### Features

- Supports all [Neotest usage](https://github.com/nvim-neotest/neotest#usage).
- Integrates with [nvim-dap-go](https://github.com/leoluz/nvim-dap-go) for  debugging of tests using delve.
- Inline diagnostics.
- Works great with  [andythigpen/nvim-coverage](https://github.com/andythigpen/nvim-coverage) for  displaying coverage in the sign column (per-Go package, or per-test basis).
- Monorepo support (detect, run and debug tests in sub-projects).
- Supports table tests (relies on treesitter AST detection).
- Supports nested test functions.
- Supports testify suites.

## Notes

- I'm the author of [fredrikaverpil/neotest-golang](https://github.com/fredrikaverpil/neotest-golang).

