### PR TITLE
Fix error when re-run same command multiple times

### DIFF
--- a/lua/telescope/_extensions/makefile_targets.lua
+++ b/lua/telescope/_extensions/makefile_targets.lua
@@ -18,21 +18,24 @@ end
 local function run_make_command(target)
   local command = "make " .. target
   local output = vim.fn.system(command)
-  -- Define the buffer name
   local buf_name = "Make Output: " .. target
+  
   -- Check if the buffer already exists and delete it
   for _, buf_id in ipairs(vim.api.nvim_list_bufs()) do
     if vim.api.nvim_buf_is_loaded(buf_id) and vim.api.nvim_buf_get_name(buf_id):match(vim.pesc(buf_name)) then
       vim.api.nvim_buf_delete(buf_id, { force = true })
     end
   end
+  
   -- Open a split at the bottom
   vim.cmd("botright new")
   local buf = vim.api.nvim_get_current_buf()
+  
   -- Rename the new buffer to avoid overwriting the previous buffer
   vim.api.nvim_buf_set_name(buf, buf_name)
   vim.api.nvim_buf_set_lines(buf, 0, -1, false, vim.split(output, "\n"))
-  vim.api.nvim_buf_set_option(buf, "modifiable", false)
+  vim.api.nvim_set_option_value("modifiable", false, { buf = buf })
+  
   -- Set the buffer to be deleted on quit
   vim.api.nvim_create_autocmd("BufLeave", {
     buffer = buf,

--- a/lua/telescope/_extensions/makefile_targets.lua
+++ b/lua/telescope/_extensions/makefile_targets.lua
@@ -5,59 +5,74 @@ local actions = require("telescope.actions")
 local action_state = require("telescope.actions.state")
 
 local function extract_makefile_targets(makefile_path)
-    local targets = {}
-    for line in io.lines(makefile_path) do
-        local target = line:match("^([%w-]+):")
-        if target then
-            table.insert(targets, target)
-        end
+  local targets = {}
+  for line in io.lines(makefile_path) do
+    local target = line:match("^([%w-]+):")
+    if target then
+      table.insert(targets, target)
     end
-    return targets
+  end
+  return targets
 end
 
 local function run_make_command(target)
-    local command = "make " .. target
-    local output = vim.fn.system(command)
-
-    -- Open a new split window and show the output
-    vim.cmd("new")
-    local buf = vim.api.nvim_get_current_buf()
-    vim.api.nvim_buf_set_lines(buf, 0, -1, false, vim.split(output, "\n"))
-    vim.api.nvim_buf_set_option(buf, "modifiable", false)
-    vim.api.nvim_buf_set_name(buf, "Make Output: " .. target)
+  local command = "make " .. target
+  local output = vim.fn.system(command)
+  -- Define the buffer name
+  local buf_name = "Make Output: " .. target
+  -- Check if the buffer already exists and delete it
+  for _, buf_id in ipairs(vim.api.nvim_list_bufs()) do
+    if vim.api.nvim_buf_is_loaded(buf_id) and vim.api.nvim_buf_get_name(buf_id):match(vim.pesc(buf_name)) then
+      vim.api.nvim_buf_delete(buf_id, { force = true })
+    end
+  end
+  -- Open a split at the bottom
+  vim.cmd("botright new")
+  local buf = vim.api.nvim_get_current_buf()
+  -- Rename the new buffer to avoid overwriting the previous buffer
+  vim.api.nvim_buf_set_name(buf, buf_name)
+  vim.api.nvim_buf_set_lines(buf, 0, -1, false, vim.split(output, "\n"))
+  vim.api.nvim_buf_set_option(buf, "modifiable", false)
+  -- Set the buffer to be deleted on quit
+  vim.api.nvim_create_autocmd("BufLeave", {
+    buffer = buf,
+    callback = function()
+      if vim.api.nvim_buf_is_valid(buf) then
+        vim.api.nvim_buf_delete(buf, { force = true })
+      end
+    end,
+  })
 end
 
 local makefile_targets = function(opts)
-    opts = opts or {}
-    local makefile_path = vim.fn.findfile("Makefile", ".;")
-
-    if makefile_path == "" then
-        print("No Makefile found in the current directory or its parents")
-        return
-    end
-
-    local targets = extract_makefile_targets(makefile_path)
-
-    pickers.new(opts, {
-        prompt_title = "Makefile Targets",
-        finder = finders.new_table {
-            results = targets
-        },
-        sorter = conf.generic_sorter(opts),
-        attach_mappings = function(prompt_bufnr, map)
-            actions.select_default:replace(function()
-                actions.close(prompt_bufnr)
-                local selection = action_state.get_selected_entry()
-                run_make_command(selection[1])
-            end)
-            return true
-        end,
-    }):find()
+  opts = opts or {}
+  local makefile_path = vim.fn.findfile("Makefile", ".;")
+  if makefile_path == "" then
+    print("No Makefile found in the current directory or its parents")
+    return
+  end
+  local targets = extract_makefile_targets(makefile_path)
+  pickers.new(opts, {
+    prompt_title = "Makefile Targets",
+    finder = finders.new_table {
+      results = targets
+    },
+    sorter = conf.generic_sorter(opts),
+    attach_mappings = function(prompt_bufnr, _)
+      actions.select_default:replace(function()
+        actions.close(prompt_bufnr)
+        local selection = action_state.get_selected_entry()
+        run_make_command(selection[1])
+      end)
+      return true
+    end,
+  }):find()
 end
 
 vim.api.nvim_create_user_command("MakefileTargets", makefile_targets, {})
+
 return require("telescope").register_extension({
-    exports = {
-        makefile_targets = makefile_targets
-    },
+  exports = {
+    makefile_targets = makefile_targets
+  },
 })


### PR DESCRIPTION
I faced issue when typing on generated buffer `:q` when I ran the command again I get an error that I can't name the buffer ( because old buffer still there ) Also force open the window bottom split.

This fix will make sure that buffer is destroyed when leaving it or when creating new one with same command.